### PR TITLE
Release/1.2.2

### DIFF
--- a/editor/components/editor/index.jsx
+++ b/editor/components/editor/index.jsx
@@ -159,19 +159,17 @@ export default class Editor extends Component {
     const editor = this.editor.current;
     const block = findBlockByName(type);
 
-    editor.change(change => {
-      if (block && block.insert) {
-        block.insert(change, data);
-      } else {
-        change.insertBlock({
-          type,
-          data
-        });
+    if (block && block.insert) {
+      block.insert(editor, data);
+    } else {
+      editor.insertBlock({
+        type,
+        data
+      });
 
-        change.focus();
-        change.moveFocusToStartOfText();
-      }
-    });
+      editor.focus();
+      editor.moveFocusToStartOfText();
+    }
   };
 
   renderNode = (props, next) => {

--- a/editor/components/editor/index.jsx
+++ b/editor/components/editor/index.jsx
@@ -27,7 +27,7 @@ const collectAndInlineStyles = (placeholder, html) => {
 };
 
 const replaceDoctype = (placeholder, html) =>
-  html.replace(placeholder, '<!doctype html />');
+  html.replace(placeholder, '<!doctype html>');
 
 const downloadFile = (title, zip) => {
   const fileName = slugify(title, {

--- a/editor/components/editor/with-block-toolbar/styles-edit-block.js
+++ b/editor/components/editor/with-block-toolbar/styles-edit-block.js
@@ -1,7 +1,5 @@
 import css from 'styled-jsx/css';
 
-import { fonts } from '../../../tokens';
-
 export default css`
   .block {
     position: relative;

--- a/editor/components/editor/with-block-toolbar/toolbar/index.jsx
+++ b/editor/components/editor/with-block-toolbar/toolbar/index.jsx
@@ -33,18 +33,16 @@ export default class Toolbar extends Component {
         {}
       );
 
-      editor.change(change => {
-        change.removeNodeByKey(node.key);
+      editor.removeNodeByKey(node.key);
 
-        if (block.insert) {
-          block.insert(change, updatedData);
-        } else {
-          change.insertBlock({
-            type,
-            data: updatedData
-          });
-        }
-      });
+      if (block.insert) {
+        block.insert(editor, updatedData);
+      } else {
+        editor.insertBlock({
+          type,
+          data: updatedData
+        });
+      }
 
       this.hideModal();
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regalsystem-builder",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/template/components/blockquote/index.jsx
+++ b/template/components/blockquote/index.jsx
@@ -64,7 +64,7 @@ export default {
     <Blockquote data={node.data}>{children}</Blockquote>
   ),
 
-  insert(change) {
-    change.insertBlock(BLOCK_DEFINITION);
+  insert(editor) {
+    editor.insertBlock(BLOCK_DEFINITION);
   }
 };

--- a/template/components/image/index.jsx
+++ b/template/components/image/index.jsx
@@ -136,10 +136,10 @@ export default {
     };
   },
 
-  insert(change, data) {
+  insert(editor, data) {
     // pass data to block
     BLOCK_DEFINITION.data = data;
 
-    change.insertBlock(BLOCK_DEFINITION);
+    editor.insertBlock(BLOCK_DEFINITION);
   }
 };

--- a/template/components/infobox/index.jsx
+++ b/template/components/infobox/index.jsx
@@ -65,7 +65,7 @@ export default {
 
   serialize: (node, children) => <InfoBox data={node.data}>{children}</InfoBox>,
 
-  insert(change) {
-    change.insertBlock(BLOCK_DEFINITION);
+  insert(editor) {
+    editor.insertBlock(BLOCK_DEFINITION);
   }
 };

--- a/template/components/intro-container/index.jsx
+++ b/template/components/intro-container/index.jsx
@@ -230,7 +230,7 @@ export default {
     <IntroContainer data={node.data}>{children}</IntroContainer>
   ),
 
-  insert(change, data) {
+  insert(editor, data) {
     BLOCK_DEFINITION.data = data;
 
     // pass data to all nodes
@@ -249,8 +249,8 @@ export default {
     }
 
     // Always add the intro of the beginning of the document
-    change.moveStartToStartOfDocument();
-    change.insertBlock(BLOCK_DEFINITION);
+    editor.moveStartToStartOfDocument();
+    editor.insertBlock(BLOCK_DEFINITION);
   },
 
   disabled(ast) {

--- a/template/components/intro-container/index.jsx
+++ b/template/components/intro-container/index.jsx
@@ -135,7 +135,7 @@ export default {
     <IntroContainer data={node.data} {...rest} />
   ),
 
-  onSelect() {
+  onSelect(data = {}) {
     return {
       fields: [
         <InputImage
@@ -161,6 +161,7 @@ export default {
         <Radio
           name="publisher"
           label="Publisher"
+          defaultValue={data.publisher}
           choices={[
             ['taz', 'taz'],
             ['gazeta', 'Gazeta'],
@@ -174,6 +175,7 @@ export default {
           name="publisher-home-link"
           helpText="A link to the homepage of the publisher (e.g. https://taz.de/)"
           label="Home link"
+          defaultValue={data['publisher-home-link']}
         />,
         <Input
           type="hidden"


### PR DESCRIPTION
-  Intro: fill publisher and home link in select form 
-  Editor: do not self-close doctype
-  Editor: replace Change with Editor, since it's deprecated with slate@0.43